### PR TITLE
Fix AMD registration.

### DIFF
--- a/sparkles.js
+++ b/sparkles.js
@@ -5,7 +5,7 @@
 
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['sparkles'], factory);
+    define('', [], factory);
     return;
   }
   if (typeof exports === 'object') {


### PR DESCRIPTION
When defining a named AMD module, the first argument should be a string. Dependencies are passed as an array of strings as the second argument.

This line was causing me issues with webpack as the module was trying to depend on itself.